### PR TITLE
Add Swift 6 support

### DIFF
--- a/Package@swift-6.swift
+++ b/Package@swift-6.swift
@@ -1,0 +1,24 @@
+// swift-tools-version:6.0
+import PackageDescription
+
+let package = Package(
+    name: "AnyDate",
+    products: [
+        .library(name: "AnyDate", targets: ["AnyDate"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "AnyDate",
+            dependencies: [],
+            path: "Sources/AnyDate"
+        ),
+        .testTarget(
+            name: "AnyDateTests",
+            dependencies: [
+                "AnyDate"
+            ],
+            path: "Tests/AnyDateTests"
+        )
+    ]
+)

--- a/Sources/AnyDate/Clock.swift
+++ b/Sources/AnyDate/Clock.swift
@@ -281,3 +281,12 @@ extension Clock: Codable {
     }
 }
 #endif
+
+#if swift(>=5.5)
+/// Clock is marked as @unchecked Sendable because it contains a TimeZone reference.
+/// This is safe because:
+/// - TimeZone is only read after initialization (Foundation's TimeZone is thread-safe for reads)
+/// - Clock is a value type, so copies are made when passed across actor boundaries
+/// - Each copy has independent mutable state
+extension Clock: @unchecked Sendable {}
+#endif

--- a/Sources/AnyDate/ClockIdentifierName.swift
+++ b/Sources/AnyDate/ClockIdentifierName.swift
@@ -1320,3 +1320,7 @@ public enum ClockIdentifierName: String {
     /// UTC +00:00
     case utc = "UTC"
 }
+
+#if swift(>=5.5)
+extension ClockIdentifierName: Sendable {}
+#endif

--- a/Sources/AnyDate/Instant.swift
+++ b/Sources/AnyDate/Instant.swift
@@ -6,10 +6,10 @@ public struct Instant {
 
     internal struct Constant {
         /// The minimum supported epoch second.
-        static var minSecond: Int64 = -31_557_014_167_219_200
+        static let minSecond: Int64 = -31_557_014_167_219_200
 
         /// The maximum supported epoch second.
-        static var maxSecond: Int64 = 31_556_889_864_403_199
+        static let maxSecond: Int64 = 31_556_889_864_403_199
     }
     
     
@@ -551,4 +551,11 @@ extension Instant: Codable {
         try container.encode(self.internalNano, forKey: .nano)
     }
 }
+#endif
+
+#if swift(>=5.5)
+extension Instant: Sendable {}
+extension Instant.Constant: Sendable {}
+extension Instant.Component: Sendable {}
+extension Instant.UntilComponent: Sendable {}
 #endif

--- a/Sources/AnyDate/LocalDate.swift
+++ b/Sources/AnyDate/LocalDate.swift
@@ -862,3 +862,12 @@ extension LocalDate: Codable {
     }
 }
 #endif
+
+#if swift(>=5.5)
+extension LocalDate: Sendable {}
+extension LocalDate.Constant: Sendable {}
+extension LocalDate.Component: Sendable {}
+extension LocalDate.PlusComponent: Sendable {}
+extension LocalDate.RangeComponent: Sendable {}
+extension LocalDate.UntilComponent: Sendable {}
+#endif

--- a/Sources/AnyDate/LocalDateTime.swift
+++ b/Sources/AnyDate/LocalDateTime.swift
@@ -896,3 +896,11 @@ extension LocalDateTime: Codable {
     }
 }
 #endif
+
+#if swift(>=5.5)
+extension LocalDateTime: Sendable {}
+extension LocalDateTime.Component: Sendable {}
+extension LocalDateTime.PlusComponent: Sendable {}
+extension LocalDateTime.RangeComponent: Sendable {}
+extension LocalDateTime.UntilComponent: Sendable {}
+#endif

--- a/Sources/AnyDate/LocalTime.swift
+++ b/Sources/AnyDate/LocalTime.swift
@@ -811,3 +811,12 @@ extension LocalTime: Codable {
     }
 }
 #endif
+
+#if swift(>=5.5)
+extension LocalTime: Sendable {}
+extension LocalTime.Constant: Sendable {}
+extension LocalTime.Component: Sendable {}
+extension LocalTime.PlusComponent: Sendable {}
+extension LocalTime.RangeComponent: Sendable {}
+extension LocalTime.UntilComponent: Sendable {}
+#endif

--- a/Sources/AnyDate/Period.swift
+++ b/Sources/AnyDate/Period.swift
@@ -69,7 +69,7 @@ public struct Period {
         total += Int64(minute) * LocalTime.Constant.nanosPerMinute
         total += Int64(second) * LocalTime.Constant.nanosPerSecond
         total += Int64(nano)
-        
+
         let dayAppend: Int
         if total < 0 {
             dayAppend = Int(total / LocalTime.Constant.nanosPerDay) - 1
@@ -78,27 +78,27 @@ public struct Period {
             dayAppend = Int(total / LocalTime.Constant.nanosPerDay)
             total %= LocalTime.Constant.nanosPerDay
         }
-        
+
         self.internalNano = Int(total % LocalTime.Constant.nanosPerSecond)
         total /= LocalTime.Constant.nanosPerSecond
-        
+
         self.internalSecond = Int(total % Int64(LocalTime.Constant.secondsPerMinute))
         total /= Int64(LocalTime.Constant.secondsPerMinute)
-        
+
         self.internalMinute = Int(total % Int64(LocalTime.Constant.minutesPerHour))
         self.internalHour = Int(total / Int64(LocalTime.Constant.minutesPerHour))
 
         let days = day + dayAppend
 
-        var newDate = LocalDate(year: year, month: month + 1, day: days + 1)
+        let newDate = LocalDate(year: year, month: month + 1, day: days + 1)
         self.internalYear = newDate.year
         self.internalMonth = newDate.month - 1
         self.internalDay = newDate.day - 1
     }
 
-    
+
     // MARK: - Operator
-    
+
     /// Period
     static public func + (lhs: Period, rhs: Period) -> Period {
         return Period(
@@ -140,7 +140,7 @@ public struct Period {
         lhs.second -= rhs.second
         lhs.nano -= rhs.nano
     }
-    
+
     /// LocalDateTime
     static public func + (lhs: LocalDateTime, rhs: Period) -> LocalDateTime {
         return LocalDateTime(
@@ -182,7 +182,7 @@ public struct Period {
         lhs.second -= rhs.second
         lhs.nano -= rhs.nano
     }
-    
+
     /// ZonedDateTime
     static public func + (lhs: ZonedDateTime, rhs: Period) -> ZonedDateTime {
         return ZonedDateTime(
@@ -226,8 +226,8 @@ public struct Period {
         lhs.second -= rhs.second
         lhs.nano -= rhs.nano
     }
-    
-    
+
+
     // MARK: - Lifecycle
 
     /// Creates an instance of LocalDateTime from year, month,
@@ -245,7 +245,7 @@ public struct Period {
 }
 
 extension Period: Comparable {
-    
+
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is less than that of the second argument.
     public static func <(lhs: Period, rhs: Period) -> Bool {
@@ -257,7 +257,7 @@ extension Period: Comparable {
         guard lhs.second == rhs.second else { return lhs.second < rhs.second }
         return lhs.nano < rhs.nano
     }
-    
+
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is greater than that of the second argument.
     public static func >(lhs: Period, rhs: Period) -> Bool {
@@ -269,22 +269,22 @@ extension Period: Comparable {
         guard lhs.second == rhs.second else { return lhs.second > rhs.second }
         return lhs.nano > rhs.nano
     }
-    
+
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is less than or equal to that of the second argument.
     public static func <=(lhs: Period, rhs: Period) -> Bool {
         return !(lhs > rhs)
     }
-    
+
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is greater than or equal to that of the second argument.
     public static func >=(lhs: Period, rhs: Period) -> Bool {
         return !(lhs < rhs)
     }
-    
+
 }
 extension Period: Hashable {
-    
+
 #if swift(>=4.2)
     /// Hashes the essential components of this value by feeding them into the
     /// given hasher.
@@ -321,7 +321,7 @@ extension Period: Hashable {
 #endif
 }
 extension Period: Equatable {
-    
+
     /// Returns a Boolean value indicating whether two values are equal.
     public static func ==(lhs: Period, rhs: Period) -> Bool {
         guard lhs.year == rhs.year else { return false }
@@ -333,10 +333,10 @@ extension Period: Equatable {
         guard lhs.nano == rhs.nano else { return false }
         return true
     }
-    
+
 }
 extension Period: CustomStringConvertible, CustomDebugStringConvertible {
-    
+
     /// A textual representation of this instance.
     public var description: String {
         let list: [String?] = [
@@ -347,7 +347,7 @@ extension Period: CustomStringConvertible, CustomDebugStringConvertible {
             self.internalMinute != 0 ? String(format: "%02dMin ", self.internalMinute) : nil,
             self.internalSecond != 0 || self.internalNano != 0 ? String(format: "%02d.%09dSec", self.internalSecond, self.internalNano) : nil
         ]
-        
+
         #if swift(>=4.1)
         return list
             .compactMap { $0 }
@@ -358,12 +358,12 @@ extension Period: CustomStringConvertible, CustomDebugStringConvertible {
             .joined()
         #endif
     }
-    
+
     /// A textual representation of this instance, suitable for debugging.
     public var debugDescription: String {
         return description
     }
-    
+
 }
 extension Period: CustomReflectable {
 
@@ -386,7 +386,7 @@ extension Period: CustomReflectable {
 }
 #if swift(>=4.1) || (swift(>=3.3) && !swift(>=4.0))
 extension Period: CustomPlaygroundDisplayConvertible {
-    
+
     /// Returns the custom playground description for this instance.
     ///
     /// If this type has value semantics, the instance returned should be
@@ -394,7 +394,7 @@ extension Period: CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any {
         return self.description
     }
-    
+
 }
 #else
 extension Period: CustomPlaygroundQuickLookable {

--- a/Sources/AnyDate/Period.swift
+++ b/Sources/AnyDate/Period.swift
@@ -69,7 +69,7 @@ public struct Period {
         total += Int64(minute) * LocalTime.Constant.nanosPerMinute
         total += Int64(second) * LocalTime.Constant.nanosPerSecond
         total += Int64(nano)
-
+        
         let dayAppend: Int
         if total < 0 {
             dayAppend = Int(total / LocalTime.Constant.nanosPerDay) - 1
@@ -78,27 +78,27 @@ public struct Period {
             dayAppend = Int(total / LocalTime.Constant.nanosPerDay)
             total %= LocalTime.Constant.nanosPerDay
         }
-
+        
         self.internalNano = Int(total % LocalTime.Constant.nanosPerSecond)
         total /= LocalTime.Constant.nanosPerSecond
-
+        
         self.internalSecond = Int(total % Int64(LocalTime.Constant.secondsPerMinute))
         total /= Int64(LocalTime.Constant.secondsPerMinute)
-
+        
         self.internalMinute = Int(total % Int64(LocalTime.Constant.minutesPerHour))
         self.internalHour = Int(total / Int64(LocalTime.Constant.minutesPerHour))
 
         let days = day + dayAppend
 
-        let newDate = LocalDate(year: year, month: month + 1, day: days + 1)
+        var newDate = LocalDate(year: year, month: month + 1, day: days + 1)
         self.internalYear = newDate.year
         self.internalMonth = newDate.month - 1
         self.internalDay = newDate.day - 1
     }
 
-
+    
     // MARK: - Operator
-
+    
     /// Period
     static public func + (lhs: Period, rhs: Period) -> Period {
         return Period(
@@ -140,7 +140,7 @@ public struct Period {
         lhs.second -= rhs.second
         lhs.nano -= rhs.nano
     }
-
+    
     /// LocalDateTime
     static public func + (lhs: LocalDateTime, rhs: Period) -> LocalDateTime {
         return LocalDateTime(
@@ -182,7 +182,7 @@ public struct Period {
         lhs.second -= rhs.second
         lhs.nano -= rhs.nano
     }
-
+    
     /// ZonedDateTime
     static public func + (lhs: ZonedDateTime, rhs: Period) -> ZonedDateTime {
         return ZonedDateTime(
@@ -226,8 +226,8 @@ public struct Period {
         lhs.second -= rhs.second
         lhs.nano -= rhs.nano
     }
-
-
+    
+    
     // MARK: - Lifecycle
 
     /// Creates an instance of LocalDateTime from year, month,
@@ -245,7 +245,7 @@ public struct Period {
 }
 
 extension Period: Comparable {
-
+    
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is less than that of the second argument.
     public static func <(lhs: Period, rhs: Period) -> Bool {
@@ -257,7 +257,7 @@ extension Period: Comparable {
         guard lhs.second == rhs.second else { return lhs.second < rhs.second }
         return lhs.nano < rhs.nano
     }
-
+    
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is greater than that of the second argument.
     public static func >(lhs: Period, rhs: Period) -> Bool {
@@ -269,22 +269,22 @@ extension Period: Comparable {
         guard lhs.second == rhs.second else { return lhs.second > rhs.second }
         return lhs.nano > rhs.nano
     }
-
+    
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is less than or equal to that of the second argument.
     public static func <=(lhs: Period, rhs: Period) -> Bool {
         return !(lhs > rhs)
     }
-
+    
     /// Returns a Boolean value indicating whether the value of the first
     /// argument is greater than or equal to that of the second argument.
     public static func >=(lhs: Period, rhs: Period) -> Bool {
         return !(lhs < rhs)
     }
-
+    
 }
 extension Period: Hashable {
-
+    
 #if swift(>=4.2)
     /// Hashes the essential components of this value by feeding them into the
     /// given hasher.
@@ -321,7 +321,7 @@ extension Period: Hashable {
 #endif
 }
 extension Period: Equatable {
-
+    
     /// Returns a Boolean value indicating whether two values are equal.
     public static func ==(lhs: Period, rhs: Period) -> Bool {
         guard lhs.year == rhs.year else { return false }
@@ -333,10 +333,10 @@ extension Period: Equatable {
         guard lhs.nano == rhs.nano else { return false }
         return true
     }
-
+    
 }
 extension Period: CustomStringConvertible, CustomDebugStringConvertible {
-
+    
     /// A textual representation of this instance.
     public var description: String {
         let list: [String?] = [
@@ -347,7 +347,7 @@ extension Period: CustomStringConvertible, CustomDebugStringConvertible {
             self.internalMinute != 0 ? String(format: "%02dMin ", self.internalMinute) : nil,
             self.internalSecond != 0 || self.internalNano != 0 ? String(format: "%02d.%09dSec", self.internalSecond, self.internalNano) : nil
         ]
-
+        
         #if swift(>=4.1)
         return list
             .compactMap { $0 }
@@ -358,12 +358,12 @@ extension Period: CustomStringConvertible, CustomDebugStringConvertible {
             .joined()
         #endif
     }
-
+    
     /// A textual representation of this instance, suitable for debugging.
     public var debugDescription: String {
         return description
     }
-
+    
 }
 extension Period: CustomReflectable {
 
@@ -386,7 +386,7 @@ extension Period: CustomReflectable {
 }
 #if swift(>=4.1) || (swift(>=3.3) && !swift(>=4.0))
 extension Period: CustomPlaygroundDisplayConvertible {
-
+    
     /// Returns the custom playground description for this instance.
     ///
     /// If this type has value semantics, the instance returned should be
@@ -394,7 +394,7 @@ extension Period: CustomPlaygroundDisplayConvertible {
     public var playgroundDescription: Any {
         return self.description
     }
-
+    
 }
 #else
 extension Period: CustomPlaygroundQuickLookable {
@@ -469,4 +469,8 @@ extension Period: Codable {
         try container.encode(self.internalNano, forKey: .nano)
     }
 }
+#endif
+
+#if swift(>=5.5)
+extension Period: Sendable {}
 #endif

--- a/Sources/AnyDate/ZonedDateTime.swift
+++ b/Sources/AnyDate/ZonedDateTime.swift
@@ -925,3 +925,7 @@ extension ZonedDateTime: Codable {
     }
 }
 #endif
+
+#if swift(>=5.5)
+extension ZonedDateTime: Sendable {}
+#endif

--- a/Tests/AnyDateTests/InstantTests.swift
+++ b/Tests/AnyDateTests/InstantTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import AnyDate
 
 class InstantTests: XCTestCase {
-
+    
     func testPropertySetter() {
         var zero = Instant.epoch
         zero.second = 100
@@ -121,7 +121,7 @@ class InstantTests: XCTestCase {
     func testUntil() {
         let instant1 = Instant(epochSecond: 100_000, nano: 999_000_000)
         let zero = Instant(epochSecond: 0, nano: 0)
-
+        
         XCTAssertEqual(zero.until(endInstant: instant1, component: .nanosecond), 100_000_999_000_000)
         XCTAssertEqual(zero.until(endInstant: instant1, component: .second), 100_000)
         XCTAssertEqual(zero.until(endInstant: instant1, component: .minute), 1666)
@@ -154,11 +154,11 @@ class InstantTests: XCTestCase {
     func testAddDate() {
         var oldInstant = Instant(epochSecond: 306, nano: 124_233_521)
         let addInstant = Instant(epochSecond: 10, nano: 100)
-
+        
         let newInstant = oldInstant + addInstant
         XCTAssertEqual(newInstant.second, 316)
         XCTAssertEqual(newInstant.nano, 124_233_621)
-
+        
         oldInstant += addInstant
         XCTAssertEqual(oldInstant.second, 316)
         XCTAssertEqual(oldInstant.nano, 124_233_621)
@@ -166,18 +166,18 @@ class InstantTests: XCTestCase {
     func testSubtractDate() {
         var oldInstant = Instant(epochSecond: 306, nano: 124_233_521)
         let addInstant = Instant(epochSecond: 10, nano: 100)
-
+        
         let newInstant = oldInstant - addInstant
         XCTAssertEqual(newInstant.second, 296)
         XCTAssertEqual(newInstant.nano, 124_233_421)
-
+        
         oldInstant -= addInstant
         XCTAssertEqual(oldInstant.second, 296)
         XCTAssertEqual(oldInstant.nano, 124_233_421)
     }
     func testHashable() {
         let instant = Instant(epochSecond: 100_000, nano: 999_000_000)
-
+        
         #if swift(>=4.2)
         var hasher = Hasher()
         hasher.combine(100_000)
@@ -208,7 +208,7 @@ class InstantTests: XCTestCase {
     }
     func testMirror() {
         let instant = Instant(epochSecond: 100_000, nano: 999_000_000)
-
+        
         var checkList: [String: Any] = [
             "second": Int64(100_000),
             "nano": 999_000_000

--- a/Tests/AnyDateTests/InstantTests.swift
+++ b/Tests/AnyDateTests/InstantTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import AnyDate
 
 class InstantTests: XCTestCase {
-    
+
     func testPropertySetter() {
         var zero = Instant.epoch
         zero.second = 100
@@ -38,7 +38,7 @@ class InstantTests: XCTestCase {
         XCTAssertLessThan(test1, test3)
     }
     func testNormalize() {
-        var instant = Instant(epochSecond: -100, nano: -100)
+        let instant = Instant(epochSecond: -100, nano: -100)
         XCTAssertEqual(instant.second, -101)
         XCTAssertEqual(instant.nano, 999_999_900)
     }
@@ -121,7 +121,7 @@ class InstantTests: XCTestCase {
     func testUntil() {
         let instant1 = Instant(epochSecond: 100_000, nano: 999_000_000)
         let zero = Instant(epochSecond: 0, nano: 0)
-        
+
         XCTAssertEqual(zero.until(endInstant: instant1, component: .nanosecond), 100_000_999_000_000)
         XCTAssertEqual(zero.until(endInstant: instant1, component: .second), 100_000)
         XCTAssertEqual(zero.until(endInstant: instant1, component: .minute), 1666)
@@ -154,11 +154,11 @@ class InstantTests: XCTestCase {
     func testAddDate() {
         var oldInstant = Instant(epochSecond: 306, nano: 124_233_521)
         let addInstant = Instant(epochSecond: 10, nano: 100)
-        
-        var newInstant = oldInstant + addInstant
+
+        let newInstant = oldInstant + addInstant
         XCTAssertEqual(newInstant.second, 316)
         XCTAssertEqual(newInstant.nano, 124_233_621)
-        
+
         oldInstant += addInstant
         XCTAssertEqual(oldInstant.second, 316)
         XCTAssertEqual(oldInstant.nano, 124_233_621)
@@ -166,18 +166,18 @@ class InstantTests: XCTestCase {
     func testSubtractDate() {
         var oldInstant = Instant(epochSecond: 306, nano: 124_233_521)
         let addInstant = Instant(epochSecond: 10, nano: 100)
-        
-        var newInstant = oldInstant - addInstant
+
+        let newInstant = oldInstant - addInstant
         XCTAssertEqual(newInstant.second, 296)
         XCTAssertEqual(newInstant.nano, 124_233_421)
-        
+
         oldInstant -= addInstant
         XCTAssertEqual(oldInstant.second, 296)
         XCTAssertEqual(oldInstant.nano, 124_233_421)
     }
     func testHashable() {
         let instant = Instant(epochSecond: 100_000, nano: 999_000_000)
-        
+
         #if swift(>=4.2)
         var hasher = Hasher()
         hasher.combine(100_000)
@@ -208,7 +208,7 @@ class InstantTests: XCTestCase {
     }
     func testMirror() {
         let instant = Instant(epochSecond: 100_000, nano: 999_000_000)
-        
+
         var checkList: [String: Any] = [
             "second": Int64(100_000),
             "nano": 999_000_000

--- a/Tests/AnyDateTests/SendableTests.swift
+++ b/Tests/AnyDateTests/SendableTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+import Foundation
+import AnyDate
+
+#if swift(>=5.5)
+/// Tests that verify Sendable conformance for all AnyDate types.
+/// These tests will fail to compile if Sendable conformance is broken.
+final class SendableTests: XCTestCase {
+
+    func testInstantIsSendable() async {
+        let instant = Instant()
+        await withTaskGroup(of: Int64.self) { group in
+            group.addTask {
+                return instant.second
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testLocalDateIsSendable() async {
+        let date = LocalDate(year: 2024, month: 1, day: 1)
+        await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                return date.year
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testLocalTimeIsSendable() async {
+        let time = LocalTime(hour: 12, minute: 0, second: 0)
+        await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                return time.hour
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testLocalDateTimeIsSendable() async {
+        let dateTime = LocalDateTime(year: 2024, month: 1, day: 1, hour: 12, minute: 0, second: 0)
+        await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                return dateTime.year
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testClockIsSendable() async {
+        let clock = Clock.UTC
+        await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                return clock.offsetSecond
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testZonedDateTimeIsSendable() async {
+        let zdt = ZonedDateTime(clock: .UTC)
+        await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                return zdt.year
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testPeriodIsSendable() async {
+        let period = 1.year
+        await withTaskGroup(of: Int.self) { group in
+            group.addTask {
+                return period.year
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testClockIdentifierNameIsSendable() async {
+        let identifier = ClockIdentifierName.utc
+        await withTaskGroup(of: String.self) { group in
+            group.addTask {
+                return identifier.rawValue
+            }
+            for await _ in group {}
+        }
+    }
+
+    func testConcurrentClockAccess() async {
+        let clock = Clock.UTC
+
+        await withTaskGroup(of: Int.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    return clock.offsetSecond
+                }
+            }
+
+            for await offset in group {
+                XCTAssertEqual(offset, 0)
+            }
+        }
+    }
+
+    func testConcurrentDateTimeCreation() async {
+        await withTaskGroup(of: LocalDateTime.self) { group in
+            for i in 0..<100 {
+                group.addTask {
+                    return LocalDateTime(year: 2024, month: 1, day: (i % 28) + 1, hour: 12, minute: 0, second: 0)
+                }
+            }
+
+            var count = 0
+            for await _ in group {
+                count += 1
+            }
+            XCTAssertEqual(count, 100)
+        }
+    }
+}
+#endif

--- a/Tests/AnyDateTests/ZonedDateTimeTests.swift
+++ b/Tests/AnyDateTests/ZonedDateTimeTests.swift
@@ -15,7 +15,7 @@ class ZonedDateTimeTests: XCTestCase {
         min.minute = 2
         min.second = -12
         min.nano = -125_221
-        
+
         XCTAssertEqual(min.year, 100)
         XCTAssertEqual(min.month, 1)
         XCTAssertEqual(min.day, 19)
@@ -161,7 +161,7 @@ class ZonedDateTimeTests: XCTestCase {
 
         let date = Date()
 
-        let localDate1 = ZonedDateTime(timeZone: utcCalendar.timeZone)
+        let localDate1 = ZonedDateTime(date, timeZone: utcCalendar.timeZone)
         let localDate2 = ZonedDateTime(date, timeZone: utcCalendar.timeZone)
         XCTAssertEqual(localDate2.year, utcCalendar.component(.year, from: date))
         XCTAssertEqual(localDate2.month, utcCalendar.component(.month, from: date))
@@ -359,12 +359,12 @@ class ZonedDateTimeTests: XCTestCase {
         dateFormatter1.dateFormat = "yyyy--MM-dd...HH.mm.ss.SSSZZZZZ"
         let date2 = ZonedDateTime.parse("2014--11-12...12.44.52.123+00:00", formatter: dateFormatter1, timeZone: self.utcTimeZone)
         XCTAssertEqual(date1, date2)
-        
+
         let dateFormatter2 = DateFormatter()
         dateFormatter2.dateFormat = "yyyy--sadgasdgasdg"
         let date3 = ZonedDateTime.parse("2014--11-12...12.44.52.123+00:00", formatter: dateFormatter2, timeZone: self.utcTimeZone)
         XCTAssertEqual(date3, nil)
-        
+
         let date4 = ZonedDateTime.parse("2014sadg", timeZone: self.utcTimeZone)
         XCTAssertEqual(date4, nil)
     }
@@ -379,10 +379,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 59)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate += addDate
         XCTAssertEqual(oldDate, newDate)
-        
+
         newDate = oldDate + addDate.localDateTime
         XCTAssertEqual(newDate.year, 1000)
         XCTAssertEqual(newDate.month, 3)
@@ -391,10 +391,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 7)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate += addDate.localDateTime
         XCTAssertEqual(oldDate, newDate)
-        
+
         newDate = oldDate + addDate.localDate
         XCTAssertEqual(newDate.year, 1000)
         XCTAssertEqual(newDate.month, 4)
@@ -403,10 +403,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 7)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate += addDate.localDate
         XCTAssertEqual(oldDate, newDate)
-        
+
         newDate = oldDate + addDate.localTime
         XCTAssertEqual(newDate.year, 1000)
         XCTAssertEqual(newDate.month, 4)
@@ -415,7 +415,7 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 15)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate += addDate.localTime
         XCTAssertEqual(oldDate, newDate)
     }
@@ -430,10 +430,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 43)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate -= addDate
         XCTAssertEqual(oldDate, newDate)
-        
+
         newDate = oldDate - addDate.localDateTime
         XCTAssertEqual(newDate.year, 999)
         XCTAssertEqual(newDate.month, 11)
@@ -442,10 +442,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 35)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate -= addDate.localDateTime
         XCTAssertEqual(oldDate, newDate)
-        
+
         newDate = oldDate - addDate.localDate
         XCTAssertEqual(newDate.year, 999)
         XCTAssertEqual(newDate.month, 9)
@@ -454,10 +454,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 35)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate -= addDate.localDate
         XCTAssertEqual(oldDate, newDate)
-        
+
         newDate = oldDate - addDate.localTime
         XCTAssertEqual(newDate.year, 999)
         XCTAssertEqual(newDate.month, 9)
@@ -466,7 +466,7 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 27)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-        
+
         oldDate -= addDate.localTime
         XCTAssertEqual(oldDate, newDate)
     }
@@ -488,7 +488,7 @@ class ZonedDateTimeTests: XCTestCase {
     }
     func testHashable() {
         let date = ZonedDateTime(year: 1999, month: 10, day: 31, hour: 11, minute: 51, second: 18, nanoOfSecond: 153_000_000, clock: .UTC)
-        
+
         #if swift(>=4.2)
         var hasher = Hasher()
         hasher.combine(date.clock)
@@ -519,7 +519,7 @@ class ZonedDateTimeTests: XCTestCase {
     }
     func testMirror() {
         let date = ZonedDateTime(year: 1999, month: 10, day: 31, hour: 11, minute: 51, second: 18, nanoOfSecond: 153_000_000, clock: .UTC)
-        
+
         var checkList: [String: Any] = [
             "year": 1999,
             "month": 10,

--- a/Tests/AnyDateTests/ZonedDateTimeTests.swift
+++ b/Tests/AnyDateTests/ZonedDateTimeTests.swift
@@ -15,7 +15,7 @@ class ZonedDateTimeTests: XCTestCase {
         min.minute = 2
         min.second = -12
         min.nano = -125_221
-
+        
         XCTAssertEqual(min.year, 100)
         XCTAssertEqual(min.month, 1)
         XCTAssertEqual(min.day, 19)
@@ -359,12 +359,12 @@ class ZonedDateTimeTests: XCTestCase {
         dateFormatter1.dateFormat = "yyyy--MM-dd...HH.mm.ss.SSSZZZZZ"
         let date2 = ZonedDateTime.parse("2014--11-12...12.44.52.123+00:00", formatter: dateFormatter1, timeZone: self.utcTimeZone)
         XCTAssertEqual(date1, date2)
-
+        
         let dateFormatter2 = DateFormatter()
         dateFormatter2.dateFormat = "yyyy--sadgasdgasdg"
         let date3 = ZonedDateTime.parse("2014--11-12...12.44.52.123+00:00", formatter: dateFormatter2, timeZone: self.utcTimeZone)
         XCTAssertEqual(date3, nil)
-
+        
         let date4 = ZonedDateTime.parse("2014sadg", timeZone: self.utcTimeZone)
         XCTAssertEqual(date4, nil)
     }
@@ -379,10 +379,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 59)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate += addDate
         XCTAssertEqual(oldDate, newDate)
-
+        
         newDate = oldDate + addDate.localDateTime
         XCTAssertEqual(newDate.year, 1000)
         XCTAssertEqual(newDate.month, 3)
@@ -391,10 +391,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 7)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate += addDate.localDateTime
         XCTAssertEqual(oldDate, newDate)
-
+        
         newDate = oldDate + addDate.localDate
         XCTAssertEqual(newDate.year, 1000)
         XCTAssertEqual(newDate.month, 4)
@@ -403,10 +403,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 7)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate += addDate.localDate
         XCTAssertEqual(oldDate, newDate)
-
+        
         newDate = oldDate + addDate.localTime
         XCTAssertEqual(newDate.year, 1000)
         XCTAssertEqual(newDate.month, 4)
@@ -415,7 +415,7 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 15)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate += addDate.localTime
         XCTAssertEqual(oldDate, newDate)
     }
@@ -430,10 +430,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 43)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate -= addDate
         XCTAssertEqual(oldDate, newDate)
-
+        
         newDate = oldDate - addDate.localDateTime
         XCTAssertEqual(newDate.year, 999)
         XCTAssertEqual(newDate.month, 11)
@@ -442,10 +442,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 35)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate -= addDate.localDateTime
         XCTAssertEqual(oldDate, newDate)
-
+        
         newDate = oldDate - addDate.localDate
         XCTAssertEqual(newDate.year, 999)
         XCTAssertEqual(newDate.month, 9)
@@ -454,10 +454,10 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 35)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate -= addDate.localDate
         XCTAssertEqual(oldDate, newDate)
-
+        
         newDate = oldDate - addDate.localTime
         XCTAssertEqual(newDate.year, 999)
         XCTAssertEqual(newDate.month, 9)
@@ -466,7 +466,7 @@ class ZonedDateTimeTests: XCTestCase {
         XCTAssertEqual(newDate.minute, 27)
         XCTAssertEqual(newDate.second, 18)
         XCTAssertEqual(newDate.nano, 1573)
-
+        
         oldDate -= addDate.localTime
         XCTAssertEqual(oldDate, newDate)
     }
@@ -488,7 +488,7 @@ class ZonedDateTimeTests: XCTestCase {
     }
     func testHashable() {
         let date = ZonedDateTime(year: 1999, month: 10, day: 31, hour: 11, minute: 51, second: 18, nanoOfSecond: 153_000_000, clock: .UTC)
-
+        
         #if swift(>=4.2)
         var hasher = Hasher()
         hasher.combine(date.clock)
@@ -519,7 +519,7 @@ class ZonedDateTimeTests: XCTestCase {
     }
     func testMirror() {
         let date = ZonedDateTime(year: 1999, month: 10, day: 31, hour: 11, minute: 51, second: 18, nanoOfSecond: 153_000_000, clock: .UTC)
-
+        
         var checkList: [String: Any] = [
             "year": 1999,
             "month": 10,


### PR DESCRIPTION
This PR adds support for Swift 6 by adding `Sendable` conformances and a few other minor changes. I don't believe any of this an API breaking change.